### PR TITLE
Fix TypeScript 6 compilation errors

### DIFF
--- a/src/PersonalWebApp/Scripts/shell.ts
+++ b/src/PersonalWebApp/Scripts/shell.ts
@@ -6,7 +6,7 @@
 declare var textrotator: JQueryStatic;
 declare var backstretch: JQueryStatic;
 
-module ifesenko.com.Shell {
+namespace ifesenko.com.Shell {
     $("#home").backstretch($("#home").data("image-source"));
 
     $(window).on('load', function() {

--- a/src/PersonalWebApp/tsconfig.json
+++ b/src/PersonalWebApp/tsconfig.json
@@ -1,9 +1,18 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "target": "es5",
+    "ignoreDeprecations": "6.0",
     "sourceMap": false,
-    "removeComments": true
+    "removeComments": true,
+    "types": ["jquery", "bootstrap"],
+    "strict": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false
   },
+  "include": [
+    "Scripts/**/*.ts"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
The TypeScript 5.9.3 → 6.0.2 bump (#311) broke the front-end build: TS 6 enables `strict` by default, tightened name resolution, and now errors on the legacy `module` keyword, so `Scripts/shell.ts` and `Scripts/jquery.simple-text-rotator.ts` would no longer compile under the gulp pipeline.

Rather than roll TypeScript back, the fix restores the previous behavior via config plus a tiny source tweak:

- `src/PersonalWebApp/tsconfig.json`
  - Add `"types": ["jquery", "bootstrap"]` so `$`, `jQuery`, `JQueryStatic`, `JQuery`, and `.collapse()` resolve again (the packages are already in `dependencies`).
  - Add `"include": ["Scripts/**/*.ts"]` to pin the compilation set.
  - Set `"target": "es5"` with `"ignoreDeprecations": "6.0"` to keep emitting the same JS the site already ships (TS 6 deprecates ES5 with a hard error unless opted out).
  - Explicitly set `"strict": false`, `"noImplicitAny": false`, `"noImplicitThis": false` to counter TS 6's new defaults.
- `src/PersonalWebApp/Scripts/shell.ts`
  - Replace the legacy `module ifesenko.com.Shell { ... }` with `namespace ifesenko.com.Shell { ... }` (fixes TS1540). Emitted JS is equivalent.

No changes to `gulpfile.mjs` or the text-rotator source were needed.

Verified locally in `src/PersonalWebApp`:
- `npx tsc --noEmit` exits clean.
- `npx gulp code` builds `wwwroot/js/app.js` successfully (3.02 kB -> 1.43 kB after minify).