### PR TITLE
Skip SWA deploy when token is missing (fix Dependabot PR checks)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,3 +54,7 @@ jobs:
           skip_api_build: true
           app_location: publish/wwwroot
           output_location: ""
+          # Dependabot PRs don't have access to repository/environment secrets,
+          # so the deploy token is empty. Still run the build to validate the
+          # dependency bump, but skip the deploy step instead of failing.
+          skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
## Problem

All Dependabot PRs (e.g. #328) are failing the `Build and Deploy` check with:

```
deployment_token was not provided.
An unknown exception has occurred
```

The dotnet build and publish steps succeed — only the final `Azure/static-web-apps-deploy@v1` step fails.

## Root cause

Dependabot-triggered workflow runs use a **separate secret store** (Settings → Secrets and variables → **Dependabot**) and do not have access to regular repository or environment secrets. `secrets.AZURE_STATIC_WEB_APPS_API_TOKEN` therefore evaluates to an empty string on every Dependabot PR, and the deploy step fails.

The existing `if:` guard on the job only skips PRs from **forks**, not Dependabot.

## Fix

Add `skip_deploy_on_missing_secrets: true` to the `Azure/static-web-apps-deploy@v1` step. The build still runs on Dependabot PRs (so we keep validating that the bump actually compiles), and the deploy step now cleanly no-ops when the token is absent instead of erroring out.

For non-Dependabot PRs and `push` to `main`, behavior is unchanged — the token is present, so the deploy runs as before.

## Verification

After this merges, rebase/retrigger #328 and the `Build and Deploy` check should go green.