### PR TITLE
Add custom domains for ifesenko.com to Static Web App

### DIFF
--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -6,9 +6,10 @@ param staticWebAppLocation = 'centralus'
 param staticWebAppName = 'swa-ifesenko'
 param sku = 'Standard'
 
-// Leave empty for the initial deployment. Add custom domains after DNS
-// records (TXT validation + CNAME/ALIAS) are configured with the registrar.
-param customDomains = []
+param customDomains = [
+  'ifesenko.com'
+  'www.ifesenko.com'
+]
 
 param deployManagedIdentity = true
 param managedIdentityName = 'id-ifesenko-github'


### PR DESCRIPTION
## Why

The Static Web App is live but only reachable via its default `*.azurestaticapps.net` hostname. This registers `ifesenko.com` and `www.ifesenko.com` as custom domains so the site is served under its own domain with auto-provisioned TLS certificates.

## What changed

Updated `infra/main.bicepparam` to set `customDomains` to `['ifesenko.com', 'www.ifesenko.com']` (previously empty).

No other infrastructure changes are needed -- the `staticWebApp.bicep` module already loops over the `customDomains` array to create `Microsoft.Web/staticSites/customDomains` resources, and the Standard SKU with enterprise-grade CDN (Azure Front Door) supports apex domain binding natively.

## Before deploying

DNS records must be configured at GoDaddy **before** running the Infra workflow, otherwise Azure domain validation will fail:

1. Add a `TXT` record: `_dnsauth` with the validation token from the Azure Portal (Static Web App -> Custom domains -> Add).
2. Add a `CNAME` record: `www` pointing to the SWA default hostname.
3. Wait for DNS propagation.

Then run the **Infra** workflow with `what-if: false` to apply.