### PR TITLE
fix: skip role assignment when deploying principal lacks Owner permissions

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -29,8 +29,11 @@ param sku string = 'Standard'
 @description('Custom domains to bind to the Static Web App (e.g. ifesenko.com, www.ifesenko.com). DNS records must be configured out-of-band.')
 param customDomains array = []
 
-@description('Whether to provision a user-assigned managed identity for GitHub Actions OIDC login and grant it Contributor on the subscription.')
+@description('Whether to provision a user-assigned managed identity for GitHub Actions OIDC login.')
 param deployManagedIdentity bool = true
+
+@description('Whether to create a subscription-scoped Contributor role assignment for the managed identity. Requires the deploying principal to have Owner or User Access Administrator role. Set to false when the deploying principal only has Contributor permissions and handle the role assignment out-of-band.')
+param deployRoleAssignment bool = true
 
 @description('Name of the user-assigned managed identity used by GitHub Actions.')
 param managedIdentityName string = 'id-ifesenko-github'
@@ -88,7 +91,8 @@ module identity 'modules/identity.bicep' = if (deployManagedIdentity) {
 
 // Subscription-scoped Contributor role assignment for the UAMI.
 // The assignment name is a deterministic GUID so repeat deployments are idempotent.
-resource identityContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployManagedIdentity) {
+// Requires the deploying principal to have Owner or User Access Administrator role.
+resource identityContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployManagedIdentity && deployRoleAssignment) {
   name: guid(subscription().id, managedIdentityName, contributorRoleDefinitionId)
   properties: {
     principalId: identity!.outputs.principalId

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -12,6 +12,12 @@ param customDomains = [
 ]
 
 param deployManagedIdentity = true
+// The deploying principal (OIDC service principal) only has Contributor, which
+// cannot create role assignments. Set to true once the principal has Owner or
+// User Access Administrator, or create the role assignment manually via:
+//   az role assignment create --assignee <managed-identity-principal-id> \
+//     --role Contributor --scope /subscriptions/<subscription-id>
+param deployRoleAssignment = false
 param managedIdentityName = 'id-ifesenko-github'
 param githubRepository = 'Ky7m/ifesenko.com'
 param federatedCredentials = [


### PR DESCRIPTION
## Problem

The [Infra workflow run](https://github.com/Ky7m/ifesenko.com/actions/runs/24964765150/job/73097539992) fails with:

```
Authorization failed for template resource of type 'Microsoft.Authorization/roleAssignments'.
The client does not have permission to perform action
'Microsoft.Authorization/roleAssignments/write'.
```

The deploying service principal (OIDC) only has **Contributor** role, which cannot create role assignments. Creating `Microsoft.Authorization/roleAssignments` requires **Owner** or **User Access Administrator**.

## Fix

- Add a `deployRoleAssignment` parameter to `main.bicep` so the subscription-scoped Contributor role assignment can be toggled independently from the managed identity
- Set `deployRoleAssignment = false` in `main.bicepparam` so the workflow succeeds for all other resources (RG, SWA, managed identity, federated credentials)
- The role assignment can be created out-of-band by running:
  ```bash
  az role assignment create \
    --assignee <managed-identity-principal-id> \
    --role Contributor \
    --scope /subscriptions/<subscription-id>
  ```